### PR TITLE
Fix compile error, and set POM packaging to 'jar'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <groupId>pluralsight</groupId>
   <artifactId>java-core-libraries-jdbc</artifactId>
   <version>1.0-SNAPSHOT</version>
-  <packaging>pom</packaging>
+  <packaging>jar</packaging>
   <name>exercise-files</name>
   <description>Exercise files for the Pluralsight course, Java core libraries: JDBC by Richard Monson-Haefel</description>
   <url>https://github.com/uncommon-design/pluralsight-javacorelibraries-jdbc.git</url>

--- a/src/main/java/com/pluralsight/jdbc/m2/after/ScalarQuery.java
+++ b/src/main/java/com/pluralsight/jdbc/m2/after/ScalarQuery.java
@@ -9,19 +9,20 @@ import java.sql.ResultSet;
 public class ScalarQuery {
 
 	public static void main(String [] args){	
-		Connection conn;
-		Statement stmt;
-		ResultSet rs;
+		Connection conn = null;
+		Statement stmt = null;
+		ResultSet rs = null;
 		
-		try{	
+		try {
 				
 			conn = DriverManager.getConnection("jdbc:mysql://localhost:3306/classicmodels?user=root&password=root");			
 			stmt = conn.createStatement();    		
     		rs = stmt.executeQuery("SELECT COUNT(*) FROM products;");
     		
-    		if(rs.next()){
-    			int count = rs.getInt(1);
-    			System.out.println(" The Products table has " + count + " rows.");
+    		if(rs.next()) {
+				int count = rs.getInt(1);
+				System.out.println(" The Products table has " + count + " rows.");
+			}
     		else{
     			System.out.println("Count query on products table failed");
     		}


### PR DESCRIPTION
This PR fixes a couple of issues - specifically, the packaging element in the pom needs to be 'jar', in order to tell Maven to build a jar file. The uberize plugin was failing because the build wasn't creating a jar file with your class files in it.

There was a missing brace on an if statement which was causing a compile error, and there was a case where `conn`, `stmt` and `rs` weren't initialized, so I initialized them to `null`. Your finally code checks for `null`, so you should be all good.